### PR TITLE
Add "skip" feature for fast-forwarding dialog during development. 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -30,9 +30,17 @@ let ui = config._ui.map(function(ui){
 	return new UIView(ui);
 });
 
+// pull any dev overrides from querystring
+// @todo use something like @link https://www.npmjs.com/package/nconf for hierarchical, environment-based configs, instead of querystring
+// @todo figure out a cleaner strategy for using common-js requires alongside es6 (too lazy to google just now)
+let queryString = require('querystring').parse(window.location.toString().split('?').pop());
+if (Object.keys(queryString).indexOf('dev') !== -1) {
+	config.environment = 'development';
+}
 
 // load the narrative
 let narrative = new Narrative({
+	allowSkip: config.environment === 'development',
 	speed: config.speed,
 	perspective: config.perspective,
 	resources: resources,

--- a/src/lib/Narrative.js
+++ b/src/lib/Narrative.js
@@ -20,6 +20,9 @@ export default class Narrative {
 		this._infrastructure = options.infrastructure;
 		this._ui = options.ui;
 
+		// enable any dev features requested
+		this._setupDev(options);
+
 		// create an object of characters mapping names against their 
 		// character class instance
 		this._charactersByName = {};
@@ -223,9 +226,38 @@ export default class Narrative {
 		var previousNarrative = this.narrative[i-1];
 		var time = waitTime * 1000 + this.textLengthOffset(previousNarrative);
 		time = time/this._speed;
-		setTimeout(() => {
+		this._waitTimer = setTimeout(() => {
 			this.incrementProgress();
 			this.go();
 		}, time);
+	}
+
+	/**
+	 * Skips to the next utterance (used in development)
+	 * @private
+	 */
+	_skip() {
+		if (this._waitTimer) {
+			clearTimeout(this._waitTimer);
+		}
+		this.incrementProgress();
+		this.go();
+	}
+
+	/**
+	 * Sets up any development features that have been requested
+	 * @private
+	 * @param {object} options hash of options passed to view
+	 */
+	_setupDev(options) {
+		// Set up utterance skipping
+		if (options.allowSkip) {
+			document.body.addEventListener('keydown', (e) => {
+				var keyCode = e.keyCode || e.which;
+				if (keyCode === 190) { // '.' to skip
+					this._skip();
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
Currently activated via query string pending a discussion on the preferred approach to environment-specific configuration.

Instructions:

1) Load the app with `?dev` appended to the URL
2) Press `.` to skip to the next utterance (inspired by [a wonderful game from my childhood](https://en.wikipedia.o/rg/wiki/Indiana_Jones_and_the_Fate_of_Atlantis). I hope @sourcejedi approves)

PRing this to springboard discussion; doesn't need to be merged yet, but feel free to check out the branch and have a mooch.
